### PR TITLE
update runtime to nodejs12.x

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: sls-cognito-backend
 
 provider:
   name: aws
-  runtime: nodejs8.10
+  runtime: nodejs12.x
   profile: student1
 
 functions:


### PR DESCRIPTION
AWS deprecated the nodejs8.10 runtime.
Deploying new Lambda Functions with this runtime is blocked.
In order to be able to deploy the template I updated the runtime to nodejs12.x